### PR TITLE
Add force-disable-teleport-safety option (default false).

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -92,6 +92,8 @@ public interface ISettings extends IConf {
 
     boolean isTeleportSafetyEnabled();
 
+    boolean isForceDisableTeleportSafety();
+
     double getTeleportCooldown();
 
     double getTeleportDelay();

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -128,7 +128,7 @@ public class Settings implements net.ess3.api.ISettings {
     private boolean forceDisableTeleportSafety;
 
     private boolean _isForceDisableTeleportSafety() {
-        return config.getBoolean("force-disable-teleport-safety");
+        return config.getBoolean("force-disable-teleport-safety", false);
     }
 
     @Override

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -125,6 +125,17 @@ public class Settings implements net.ess3.api.ISettings {
         return teleportSafety;
     }
 
+    private boolean forceDisableTeleportSafety;
+
+    private boolean _isForceDisableTeleportSafety() {
+        return config.getBoolean("force-disable-teleport-safety");
+    }
+
+    @Override
+    public boolean isForceDisableTeleportSafety() {
+        return forceDisableTeleportSafety;
+    }
+
     @Override
     public double getTeleportDelay() {
         return config.getDouble("teleport-delay", 0);
@@ -471,6 +482,7 @@ public class Settings implements net.ess3.api.ISettings {
         noGodWorlds = new HashSet<String>(config.getStringList("no-god-in-worlds"));
         enabledSigns = _getEnabledSigns();
         teleportSafety = _isTeleportSafetyEnabled();
+        forceDisableTeleportSafety = _isForceDisableTeleportSafety();
         teleportInvulnerabilityTime = _getTeleportInvulnerability();
         teleportInvulnerability = _isTeleportInvulnerability();
         disableItemPickupWhileAfk = _getDisableItemPickupWhileAfk();

--- a/Essentials/src/com/earth2me/essentials/Teleport.java
+++ b/Essentials/src/com/earth2me/essentials/Teleport.java
@@ -95,7 +95,11 @@ public class Teleport implements net.ess3.api.ITeleport {
                 if (teleportee.getBase().isInsideVehicle()) {
                     teleportee.getBase().leaveVehicle();
                 }
-                teleportee.getBase().teleport(LocationUtil.getSafeDestination(teleportee, loc), cause);
+                if (ess.getSettings().isForceDisableTeleportSafety()) {
+                    teleportee.getBase().teleport(loc, cause);
+                } else {
+                    teleportee.getBase().teleport(LocationUtil.getSafeDestination(teleportee, loc), cause);
+                }
             } else {
                 throw new Exception(tl("unsafeTeleportDestination", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
             }
@@ -103,7 +107,11 @@ public class Teleport implements net.ess3.api.ITeleport {
             if (teleportee.getBase().isInsideVehicle()) {
                 teleportee.getBase().leaveVehicle();
             }
-            teleportee.getBase().teleport(LocationUtil.getRoundedDestination(loc), cause);
+            if (ess.getSettings().isForceDisableTeleportSafety()) {
+                teleportee.getBase().teleport(loc, cause);
+            } else {
+                teleportee.getBase().teleport(LocationUtil.getRoundedDestination(loc), cause);
+            }
         }
     }
 

--- a/Essentials/src/com/earth2me/essentials/utils/LocationUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/LocationUtil.java
@@ -316,6 +316,6 @@ public class LocationUtil {
             }
         }
 
-        return y < 0 ? true : false;
+        return y < 0;
     }
 }

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -46,6 +46,10 @@ change-displayname: true
 # If this is set to false, attempted teleports to unsafe locations will be cancelled with a warning.
 teleport-safety: true
 
+# This forcefully disables teleport safety checks without a warning if attempting to teleport to unsafe locations.
+# teleport-safety and this option need to be set to true to force teleportation to dangerous locations.
+force-disable-teleport-safety: false
+
 # The delay, in seconds, required between /home, /tp, etc.
 teleport-cooldown: 0
 


### PR DESCRIPTION
This option is useful for preventing "teleport-glitching" in Factions servers. The default teleport-safety option gives an error message when the destination is unsafe, but this behavior may not be desired. This allows players to teleport to any dangerous location without the teleport being blocked or the location being transformed into a "safe" one.

The teleport behavior will not change for existing users, as the default is false.

This only covers player cases (not mob spawning), I've run [this](http://i.imgur.com/jJS0oX5.png) on my Factions server with no issues, and since this PR just adds a config option, it should work the same. Still a hack, but a non-breaking hack for #21