### PR TITLE
Implement prefix and suffix methods for VaultHandler

### DIFF
--- a/Essentials/src/com/earth2me/essentials/perm/VaultHandler.java
+++ b/Essentials/src/com/earth2me/essentials/perm/VaultHandler.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials.perm;
 
 import com.earth2me.essentials.Essentials;
+import net.milkbowl.vault.chat.Chat;
 import net.milkbowl.vault.permission.Permission;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.RegisteredServiceProvider;
@@ -12,6 +13,7 @@ public class VaultHandler extends SuperpermsHandler {
 
     private Essentials plugin;
     private static Permission perms = null;
+    private static Chat chat = null;
 
     public VaultHandler(Essentials plugin) {
         this.plugin = plugin;
@@ -24,9 +26,11 @@ public class VaultHandler extends SuperpermsHandler {
             return false;
         }
 
-        RegisteredServiceProvider<Permission> rsp = plugin.getServer().getServicesManager().getRegistration(Permission.class);
-        perms = rsp.getProvider();
-        return perms != null;
+        RegisteredServiceProvider<Permission> permsProvider = plugin.getServer().getServicesManager().getRegistration(Permission.class);
+        perms = permsProvider.getProvider();
+        RegisteredServiceProvider<Chat> chatProvider = plugin.getServer().getServicesManager().getRegistration(Chat.class);
+        chat = chatProvider.getProvider();
+        return perms != null && chat != null;
     }
 
     @Override
@@ -47,5 +51,27 @@ public class VaultHandler extends SuperpermsHandler {
     @Override
     public boolean hasPermission(final Player base, String node) {
         return base.hasPermission(node);
+    }
+
+    @Override
+    public String getPrefix(final Player base) {
+        String playerPrefix = chat.getPlayerPrefix(base);
+        if (playerPrefix == null) {
+            String playerGroup = perms.getPrimaryGroup(base);
+            return chat.getGroupPrefix((String) null, playerGroup);
+        } else {
+            return playerPrefix;
+        }
+    }
+
+    @Override
+    public String getSuffix(final Player base) {
+        String playerSuffix = chat.getPlayerSuffix(base);
+        if (playerSuffix == null) {
+            String playerGroup = perms.getPrimaryGroup(base);
+            return chat.getGroupSuffix((String) null, playerGroup);
+        } else {
+            return playerSuffix;
+        }
     }
 }


### PR DESCRIPTION
This fixes issue #35, has been tested with latest Spigot zPermissions, latest Vault, and latest EssentialsX (w/ Chat).

Don't revert the previous zPermissions commit, some may use zPermissions without Vault.