### PR TITLE
Don't override SuperpermsHandler hasPermission, fixes #45

### DIFF
--- a/Essentials/src/com/earth2me/essentials/perm/VaultHandler.java
+++ b/Essentials/src/com/earth2me/essentials/perm/VaultHandler.java
@@ -50,11 +50,6 @@ public class VaultHandler extends SuperpermsHandler {
     }
 
     @Override
-    public boolean hasPermission(final Player base, String node) {
-        return base.hasPermission(node);
-    }
-
-    @Override
     public String getPrefix(final Player base) {
         String playerPrefix = chat.getPlayerPrefix(base);
         if (playerPrefix == null) {


### PR DESCRIPTION
The superclass has the proper hasPermission implementation with wildcard support. This should not be overridden.