### PR TITLE
Fix spawner functionality in 1.8, fixes #22 (and many more)

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -30,6 +30,7 @@ import com.earth2me.essentials.textreader.IText;
 import com.earth2me.essentials.textreader.KeywordReplacer;
 import com.earth2me.essentials.textreader.SimpleTextInput;
 import com.earth2me.essentials.utils.DateUtil;
+import com.earth2me.essentials.utils.SpawnerUtil;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
@@ -95,6 +96,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     private transient EssentialsTimer timer;
     private final transient List<String> vanishedPlayers = new ArrayList<String>();
     private transient Method oldGetOnlinePlayers;
+    private transient SpawnerUtil spawnerUtil;
 
     public Essentials() {
     }
@@ -128,6 +130,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
         Economy.setEss(this);
         confList = new ArrayList<IConf>();
         jails = new Jails(this);
+        spawnerUtil = new SpawnerUtil(this);
         registerListeners(server.getPluginManager());
     }
 
@@ -755,6 +758,11 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 return getUser(player);
             }
         });
+    }
+
+    @Override
+    public SpawnerUtil getSpawnerUtil() {
+        return spawnerUtil;
     }
 
     private static class EssentialsWorldListener implements Listener, Runnable {

--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -193,8 +193,8 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 confList.add(itemDb);
                 execTimer.mark("Init(Worth/ItemDB)");
                 jails = new Jails(this);
-                spawnerUtil = new SpawnerUtil(this);
                 confList.add(jails);
+                spawnerUtil = new SpawnerUtil(this);
                 reload();
             } catch (YAMLException exception) {
                 if (pm.getPlugin("EssentialsUpdate") != null) {

--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -194,6 +194,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 confList.add(itemDb);
                 execTimer.mark("Init(Worth/ItemDB)");
                 jails = new Jails(this);
+                spawnerUtil = new SpawnerUtil(this);
                 confList.add(jails);
                 reload();
             } catch (YAMLException exception) {

--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -130,7 +130,6 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
         Economy.setEss(this);
         confList = new ArrayList<IConf>();
         jails = new Jails(this);
-        spawnerUtil = new SpawnerUtil(this);
         registerListeners(server.getPluginManager());
     }
 

--- a/Essentials/src/com/earth2me/essentials/EssentialsBlockListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsBlockListener.java
@@ -36,7 +36,7 @@ public class EssentialsBlockListener implements Listener {
             final BlockState blockState = event.getBlockPlaced().getState();
             if (blockState instanceof CreatureSpawner) {
                 final CreatureSpawner spawner = (CreatureSpawner) blockState;
-                final EntityType type = EntityType.fromId(event.getItemInHand().getData().getData());
+                final EntityType type = ess.getSpawnerUtil().getEntityType(event.getItemInHand());
                 if (type != null && Mob.fromBukkitType(type) != null) {
                     if (ess.getUser(event.getPlayer()).isAuthorized("essentials.spawnerconvert." + Mob.fromBukkitType(type).name().toLowerCase(Locale.ENGLISH))) {
                         spawner.setSpawnedType(type);

--- a/Essentials/src/com/earth2me/essentials/IEssentials.java
+++ b/Essentials/src/com/earth2me/essentials/IEssentials.java
@@ -6,6 +6,7 @@ import com.earth2me.essentials.api.IWarps;
 import com.earth2me.essentials.metrics.Metrics;
 import com.earth2me.essentials.perm.PermissionsHandler;
 import com.earth2me.essentials.register.payment.Methods;
+import com.earth2me.essentials.utils.SpawnerUtil;
 import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -96,4 +97,6 @@ public interface IEssentials extends Plugin {
     Collection<Player> getOnlinePlayers();
 
     Iterable<User> getOnlineUsers();
+
+    SpawnerUtil getSpawnerUtil();
 }

--- a/Essentials/src/com/earth2me/essentials/ItemDb.java
+++ b/Essentials/src/com/earth2me/essentials/ItemDb.java
@@ -8,6 +8,7 @@ import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.*;
 import org.bukkit.potion.Potion;
@@ -136,7 +137,11 @@ public class ItemDb implements IConf, net.ess3.api.IItemDb {
         }
         final ItemStack retval = new ItemStack(mat);
         retval.setAmount(mat.getMaxStackSize());
-        retval.setDurability(metaData);
+        if (mat == Material.MOB_SPAWNER) {
+            ess.getSpawnerUtil().setEntityType(retval, EntityType.fromId(metaData));
+        } else {
+            retval.setDurability(metaData);
+        }
         return retval;
     }
 

--- a/Essentials/src/com/earth2me/essentials/ItemDb.java
+++ b/Essentials/src/com/earth2me/essentials/ItemDb.java
@@ -138,7 +138,11 @@ public class ItemDb implements IConf, net.ess3.api.IItemDb {
         final ItemStack retval = new ItemStack(mat);
         retval.setAmount(mat.getMaxStackSize());
         if (mat == Material.MOB_SPAWNER) {
-            ess.getSpawnerUtil().setEntityType(retval, EntityType.fromId(metaData));
+            try {
+                ess.getSpawnerUtil().setEntityType(retval, EntityType.fromId(metaData));
+            } catch (IllegalArgumentException e) {
+                throw new Exception("Can't spawn entity ID " + metaData + " from mob spawners.");
+            }
         } else {
             retval.setDurability(metaData);
         }

--- a/Essentials/src/com/earth2me/essentials/utils/SpawnerUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/SpawnerUtil.java
@@ -27,7 +27,7 @@ public class SpawnerUtil {
         }
     }
 
-    public ItemStack setEntityType(ItemStack is, EntityType type) {
+    public ItemStack setEntityType(ItemStack is, EntityType type) throws IllegalArgumentException {
         if (useMeta) {
             // Supported in 1.8.3-R0.1-SNAPSHOT and above
             BlockStateMeta bsm = (BlockStateMeta) is.getItemMeta();

--- a/Essentials/src/com/earth2me/essentials/utils/SpawnerUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/SpawnerUtil.java
@@ -37,7 +37,7 @@ public class SpawnerUtil {
             is.setItemMeta(bsm);
         } else {
             // Legacy behavior
-            is.setDurability((short) type.ordinal());
+            is.setDurability(type.getTypeId());
         }
         return is;
     }

--- a/Essentials/src/com/earth2me/essentials/utils/SpawnerUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/SpawnerUtil.java
@@ -1,6 +1,6 @@
 package com.earth2me.essentials.utils;
 
-import com.earth2me.essentials.Essentials;
+import net.ess3.api.IEssentials;
 import org.bukkit.Material;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
@@ -12,7 +12,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 public class SpawnerUtil {
     private boolean useMeta;
 
-    public SpawnerUtil(Essentials ess) {
+    public SpawnerUtil(IEssentials ess) {
         try {
             ItemStack is = new ItemStack(Material.MOB_SPAWNER, 1);
             ItemMeta meta = is.getItemMeta();

--- a/Essentials/src/com/earth2me/essentials/utils/SpawnerUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/SpawnerUtil.java
@@ -1,0 +1,56 @@
+package com.earth2me.essentials.utils;
+
+import com.earth2me.essentials.Essentials;
+import org.bukkit.Material;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class SpawnerUtil {
+    private boolean useMeta;
+
+    public SpawnerUtil(Essentials ess) {
+        try {
+            ItemStack is = new ItemStack(Material.MOB_SPAWNER, 1);
+            ItemMeta meta = is.getItemMeta();
+            useMeta = meta instanceof BlockStateMeta;
+        } catch (Exception e) {
+            useMeta = false;
+        }
+        if (useMeta) {
+            ess.getLogger().info("Using BlockStateMeta for spawners");
+        } else {
+            ess.getLogger().info("Using legacy item data for spawners");
+        }
+    }
+
+    public ItemStack setEntityType(EntityType type) {
+        ItemStack is = new ItemStack(Material.MOB_SPAWNER, 1);
+        if (useMeta) {
+            // Supported in 1.8.3-R0.1-SNAPSHOT and above
+            BlockStateMeta bsm = (BlockStateMeta) is.getItemMeta();
+            BlockState bs = bsm.getBlockState();
+            ((CreatureSpawner) bs).setSpawnedType(type);
+            bsm.setBlockState(bs);
+            is.setItemMeta(bsm);
+        } else {
+            // Legacy behavior
+            is.getData().setData((byte) type.ordinal());
+        }
+        return is;
+    }
+
+    public EntityType getEntityType(ItemStack is) {
+        ItemMeta meta = is.getItemMeta();
+        if (useMeta) {
+            BlockStateMeta bsm = (BlockStateMeta) is.getItemMeta();
+            CreatureSpawner bs = (CreatureSpawner) bsm.getBlockState();
+            return bs.getSpawnedType();
+        } else {
+            return EntityType.fromId((int) is.getData().getData());
+        }
+    }
+}

--- a/Essentials/src/com/earth2me/essentials/utils/SpawnerUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/SpawnerUtil.java
@@ -27,8 +27,7 @@ public class SpawnerUtil {
         }
     }
 
-    public ItemStack setEntityType(EntityType type) {
-        ItemStack is = new ItemStack(Material.MOB_SPAWNER, 1);
+    public ItemStack setEntityType(ItemStack is, EntityType type) {
         if (useMeta) {
             // Supported in 1.8.3-R0.1-SNAPSHOT and above
             BlockStateMeta bsm = (BlockStateMeta) is.getItemMeta();
@@ -38,7 +37,7 @@ public class SpawnerUtil {
             is.setItemMeta(bsm);
         } else {
             // Legacy behavior
-            is.getData().setData((byte) type.ordinal());
+            is.setDurability((short) type.ordinal());
         }
         return is;
     }


### PR DESCRIPTION
This fixes:

* Spawner convert (#22)
* /give command with spawners
* sell signs with spawners

This degrades to legacy durability/data access on pre-1.8.3.